### PR TITLE
Refactor alias-maker: Remove am() command, add lsalias, improve safety and UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,24 @@
-# Alias Maker Plugin
+# Alias Maker
 
-The Alias Maker plugin is a zsh plugin that allows you to easily create and manage custom zsh aliases from the
-command line.
-
-## Installation
-
-1.  Clone the Alias Maker repository:
-# Alias Maker Plugin
-
-Alias Maker is a zsh plugin that lets you create and manage custom aliases from the command line.
+A simple zsh plugin for creating and managing custom shell aliases from the command line.
 
 ## Installation
 
-1. Clone the repository:
+### Manual Installation
+
+1. Clone the repository to any directory:
 
 ```zsh
-git clone https://github.com/MefitHp/alias-maker.git ~/.oh-my-zsh/custom/plugins/alias-maker
+git clone https://github.com/MefitHp/alias-maker.git ~/zsh-plugins/alias-maker
 ```
 
-2. Add `alias-maker` to your plugin list in `~/.zshrc`:
+2. Source the plugin in your `~/.zshrc`:
 
 ```zsh
-plugins=(git other-plugin alias-maker)
+# Load alias-maker plugin
+if [[ -f ~/zsh-plugins/alias-maker/alias-maker.plugin.zsh ]]; then
+    source ~/zsh-plugins/alias-maker/alias-maker.plugin.zsh
+fi
 ```
 
 3. Reload your shell:
@@ -30,43 +27,65 @@ plugins=(git other-plugin alias-maker)
 source ~/.zshrc
 ```
 
+### Oh-My-Zsh Installation (Optional)
+
+If you use Oh-My-Zsh, you can install it as a custom plugin:
+
+```zsh
+git clone https://github.com/MefitHp/alias-maker.git ~/.oh-my-zsh/custom/plugins/alias-maker
+```
+
+Then add `alias-maker` to your plugins list in `~/.zshrc`:
+
+```zsh
+plugins=(git alias-maker)
+```
+
 ## Usage
 
-This plugin exposes two commands: `mkalias` and `rmalias`.
+The plugin provides three commands for managing aliases:
 
 ```zsh
 mkalias <alias_name> '<alias_command>'   # Create a new alias
-mkalias -l | --list                      # List aliases defined in your ~/.zshrc
-lsalias                                  # List aliases (shortcut)
+rmalias <alias_name>                     # Delete an alias  
+lsalias                                  # List all aliases
+```
+
+Additional options for `mkalias`:
+```zsh
+mkalias -l | --list                      # List aliases (same as lsalias)
 mkalias -h | --help                      # Show help
-rmalias <alias_name>                     # Delete an alias
 ```
 
-### Create a new alias
+### Examples
 
+**Create aliases:**
 ```zsh
-mkalias myalias 'ls -la'
+mkalias ll 'ls -la'
+mkalias gcm 'git commit -m'
+mkalias serve 'python -m http.server 8000'
 ```
 
-This appends the alias to `~/.zshrc` and sources it immediately.
-
-### Delete an alias
-
-```zsh
-rmalias myalias
-```
-
-### List aliases
-
+**List your aliases:**
 ```zsh
 lsalias
 ```
 
-Example output:
+**Remove an alias:**
+```zsh
+rmalias ll
+```
 
-```
-🔧 Custom aliases found in /Users/YOUR_USER/.zshrc:
-    - zshconfig → mate ~/.zshrc
-    - ohmyzsh  → mate ~/.oh-my-zsh
-```
-### Delete an existing custom zsh alias
+## Features
+
+- **Safe quoting**: Commands are automatically escaped to prevent issues with special characters like `$`
+- **Newline handling**: Ensures proper formatting when appending to your `.zshrc`
+- **Immediate availability**: Aliases are sourced automatically after creation
+- **Clean removal**: Deletes alias from both `.zshrc` and current shell session
+
+## Requirements
+
+- Zsh shell
+- Write access to `~/.zshrc`
+
+No framework dependencies required.

--- a/README.md
+++ b/README.md
@@ -6,26 +6,25 @@ command line.
 ## Installation
 
 1.  Clone the Alias Maker repository:
+# Alias Maker Plugin
 
-```
+Alias Maker is a zsh plugin that lets you create and manage custom aliases from the command line.
+
+## Installation
+
+1. Clone the repository:
+
+```zsh
 git clone https://github.com/MefitHp/alias-maker.git ~/.oh-my-zsh/custom/plugins/alias-maker
 ```
 
-2.  Then, add `alias-maker` to your Zsh plugins list in your `.zshrc` file:
-
-If using you're using VSCode you can open the file with the following command:
+2. Add `alias-maker` to your plugin list in `~/.zshrc`:
 
 ```zsh
-code ~/.zshrc
+plugins=(git other-plugin alias-maker)
 ```
 
-Then just update the plugins
-
-```zsh
-plugins=(plugin1 plugin2 alias-maker)
-```
-
-3.  Restart your zsh shell or update the shell.
+3. Reload your shell:
 
 ```zsh
 source ~/.zshrc
@@ -33,48 +32,41 @@ source ~/.zshrc
 
 ## Usage
 
-The Alias Maker plugin provides the following subcommands:
+This plugin exposes two commands: `mkalias` and `rmalias`.
 
-```
-amc <alias_name> <alias_command>  # Create a new custom zsh alias
-amd <alias_name>                  # Delete an existing custom zsh alias
-am --list, -l                     # List all custom zsh aliases defined in your .zshrc file
-am --help, -h                     # Show help message
-```
-
-### Create a new custom zsh alias
-
-To create a new custom zsh alias, use the `amc` (Just an `alias-maker-create` shortcut) subcommand followed by
-the name and command for the new alias:
-
-```
-amc myalias 'ls -la'
+```zsh
+mkalias <alias_name> '<alias_command>'   # Create a new alias
+mkalias -l | --list                      # List aliases defined in your ~/.zshrc
+lsalias                                  # List aliases (shortcut)
+mkalias -h | --help                      # Show help
+rmalias <alias_name>                     # Delete an alias
 ```
 
-This will create a new zsh alias named `myalias` that executes the command `ls -la`.
+### Create a new alias
 
-### Delete an existing custom zsh alias
-
-To delete an existing custom zsh alias, use the `amd` subcommand followed by the name of the alias:
-
-```
-amd myalias
+```zsh
+mkalias myalias 'ls -la'
 ```
 
-This will delete the `myalias` alias if it exists.
+This appends the alias to `~/.zshrc` and sources it immediately.
 
-### List all custom zsh aliases
+### Delete an alias
 
-To list all custom zsh aliases defined in your `.zshrc` file, use the `am --list` subcommand:
-
+```zsh
+rmalias myalias
 ```
-am --list
+
+### List aliases
+
+```zsh
+lsalias
 ```
 
 Example output:
 
 ```
 🔧 Custom aliases found in /Users/YOUR_USER/.zshrc:
-    - zshconfig → "mate ~/.zshrc"
-    - ohmyzsh →"mate ~/.oh-my-zsh"
+    - zshconfig → mate ~/.zshrc
+    - ohmyzsh  → mate ~/.oh-my-zsh
 ```
+### Delete an existing custom zsh alias


### PR DESCRIPTION
# Refactor alias-maker: Remove am() command, add lsalias, improve safety and UX

## 🎯 Overview
Major refactor of the alias-maker plugin to simplify the interface, improve safety, and enhance user experience. Removes the confusing `am()` command in favor of dedicated, intuitive commands.

## 🔧 Changes Made

### **Command Interface Improvements**
- **Removed `am()` function** - Eliminated the confusing multi-purpose command
- **Renamed commands to sensible names**:
  - `amc` → `mkalias` (create aliases)  
  - `amd` → `rmalias` (remove aliases)
- **Added `lsalias`** - Dedicated command for listing aliases
- **Enhanced `mkalias`** with helpful flags:
  - `mkalias -h | --help` - Show help
  - `mkalias -l | --list` - List aliases (alternative to `lsalias`)

### **Safety & Reliability Fixes**
- **Fixed quote handling**: Auto-escapes single quotes and uses safe quoting to prevent `$` expansion issues
- **Improved newline handling**: Ensures proper line breaks before appending to `.zshrc` (fixes cases like `fialias` concatenation)
- **Better alias detection**: Fixed `rmalias` existence check using proper `alias "$name"` detection
- **Robust deletion**: Enhanced sed pattern to handle indented alias lines

### **User Experience Improvements**
- **Consistent help/usage messages**: All commands show clear, standardized usage information
- **Better input validation**: Improved alias name validation (letters, numbers, `_`, `-`)
- **Cleaner output**: Improved alias listing format with proper quote stripping

### **Documentation Overhaul**
- **Removed oh-my-zsh dependency**: Made installation framework-agnostic
- **Added manual installation as primary method**: Works with any zsh setup
- **Improved examples**: Added real-world alias examples (`ll`, `gcm`, `serve`)
- **Documented safety features**: Highlighted automatic escaping and formatting

## 🚀 New Interface
```zsh
# Create aliases
mkalias ll 'ls -la'
mkalias gcm 'git commit -m'

# List aliases  
lsalias
# or
mkalias --list

# Remove aliases
rmalias ll

# Get help
mkalias --help
```

## 🔍 Testing
- [x] Syntax validation with `zsh -n`
- [x] Manual testing of create/list/delete workflows
- [x] Validation of quote escaping and newline handling
- [x] Confirmation that aliases work immediately after creation

## 💥 Breaking Changes
- `am` command removed - users should use `mkalias`, `rmalias`, and `lsalias` instead
- Installation no longer assumes oh-my-zsh (though still supported)

## 📋 Migration Guide
**Old → New**:
- `amc myalias 'cmd'` → `mkalias myalias 'cmd'`
- `amd myalias` → `rmalias myalias`  
- `am --list` → `lsalias` or `mkalias --list`
- `am --help` → `mkalias --help`